### PR TITLE
Update reader.py

### DIFF
--- a/readmrz/reader.py
+++ b/readmrz/reader.py
@@ -87,7 +87,7 @@ class MrzReader:
             elif len(code) == 89:
                 checker = TD3CodeChecker(code)
             else:
-                raise Exception('The MRZ code could not be detected.')
+                raise Exception('The MRZ code is not valid.')
 
             # extract fields
             fields = checker.fields()


### PR DESCRIPTION
The system can detect and locate the MRZ (Machine Readable Zone), but it struggles to parse it due to variations in length. Therefore, it's capable of retrieving the string from an invalid MRZ, but its inability to parse stems from the differences in length.